### PR TITLE
Add detailed README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Transcriber Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,48 @@
-Take a video in .mp4/.mov format <br/>
-converts it into "output.wav" <br/>
-outputs text from video in your cli <br/>
-:)
+# Transcriber
+
+Transcriber is a lightweight command-line utility that converts video or audio files into text using OpenAI's transcription models. It automatically converts `.mp4` or `.mov` files into a `wav` audio track and then sends the audio to the OpenAI API for transcription.
+
+## Features
+- Convert video files to mono 16 kHz WAV using `ffmpeg`.
+- Send audio files directly to OpenAI's `gpt-4o-transcribe` model.
+- Print the resulting transcript to the console.
+
+## Prerequisites
+- Python 3.8+
+- [`ffmpeg`](https://ffmpeg.org/) installed and available on your `PATH`.
+- An [OpenAI API key](https://platform.openai.com/) stored in a `.env` file as `OPENAI_API_KEY`.
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+1. Place your media file in the project directory.
+2. Run the script:
+   ```bash
+   python transriber.py
+   ```
+3. Enter the file name when prompted. The script will create `output.wav` and display the transcript.
+
+## Architecture
+```mermaid
+flowchart LR
+    A[Input .mp4/.mov/.wav] --> B{Is video?}
+    B -- Yes --> C[Convert to output.wav]
+    B -- No --> D[Copy to output.wav]
+    C & D --> E[OpenAI Transcription]
+    E --> F[Transcript in CLI]
+```
+
+## Environment Variables
+Create a `.env` file in the project root with your OpenAI key:
+```bash
+OPENAI_API_KEY=your_api_key_here
+```
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Contributing
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.


### PR DESCRIPTION
## Summary
- expand README with installation, usage, and architecture diagram
- include MIT license for project

## Testing
- `python -m py_compile transriber.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0612a83b883328496150a49e41f97